### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ gunicorn
 flask-htmx
 azure-ai-textanalytics
 azure-core
+Werkzeug==2.3.7


### PR DESCRIPTION
Newest version of Werkzeug got rid of url_quote() which is required to deploy this app
See moodle forum for the current error.